### PR TITLE
Fix github action ./gradlew permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,6 +32,8 @@ jobs:
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    - name: Change wrapper permissions
+      run: chmod +x ./gradlew
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build


### PR DESCRIPTION
Исправление проблемы с ./gradlew правами доступа. 

![image](https://github.com/user-attachments/assets/526e47ce-6bb1-4cca-9606-1879bbfcc9c0)
